### PR TITLE
Return early if attribution controller does not exist

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -408,6 +408,9 @@ export default class FeatureService {
     const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>'
 
     const attributionController = this._map._controls.find(c => '_attribHTML' in c)
+
+    if (!attributionController) return;
+
     const customAttribution = attributionController.options.customAttribution
 
     if (typeof customAttribution === 'string') {


### PR DESCRIPTION
Addresses https://github.com/rowanwins/mapbox-gl-arcgis-featureserver/issues/1

If attribution controller did not exist, attempting to set options on it would result in a console error