### PR TITLE
Add token functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This library exposes a single `FeatureService` class
 | `to` | `Date` | | An end date for a time-enabled layer. |
 | `useSeviceBounds` | `Boolean` | `true` | Only retrieve data for those areas within the extent advertised by the service metadata. |
 | `projectionEndpoint` | `String` | * See note below | A url of an ArcGIS Server Geometry Server which is called if the extent of the services isn't in EPSG4326. The fallback uses the ArcGIS Online instance, however please ensure that you are using the service within the [Esri licensing arrangements](https://developers.arcgis.com/faq/#licensing).|
+| `token` | `String | null` | null | The token to use when making requests to Esri. `null`, the default, will not append any token paramter to the requests. | 
 
 *Note* First tries to find a project endpoint on the Server instance based on the service URL, but falls back to using `https://tasks.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project` if it can't find one. 
 
@@ -81,6 +82,7 @@ This library exposes a single `FeatureService` class
 | setWhere(<String>query) | Redraws the layer with a new where query applied. Corresponds to the option above on the Esri Service Options. |
 | clearWhere() | Clears the where clause and redraws the layer with all features. |
 | setDate(<Date> from, <Date> to) | Redraws the layer with he passed time range. |
+| setToken(<string>token) | Updates the token associated with requests to Esri. Note that if the service requires a token, the initial value should be passed as a parameter in ArcGIS options. |
 
 
 #### Example of disabling and enabling requests

--- a/docs/src/App.vue
+++ b/docs/src/App.vue
@@ -49,7 +49,14 @@ export default {
             url: 'https://services2.arcgis.com/CcI36Pduqd0OR4W9/ArcGIS/rest/services/trafficCamerasCur_Prd/FeatureServer/0',
             srcName: 'traffic-src',
             labelField: 'name'
-          }
+          },
+          // {
+          //   name: 'Token layer ...',
+          //   url: 'https://my-authenticated-layer.com/path/to/rest/services/HiddenBoatTreasures/FeatureServer/42',
+          //   srcName: 'hidden-treasure',
+          //   labelField: 'name',
+          //   token: 'token.....'
+          // }
         ]
       }
     },

--- a/docs/src/Map.vue
+++ b/docs/src/Map.vue
@@ -44,7 +44,8 @@ export default {
     methods: {
       setUpLayer (layerOption) {
           layer = new FeatureService(layerOption.srcName, map, {
-            url: layerOption.url
+            url: layerOption.url,
+            token: layerOption.token || null,
           })
 
           map.addLayer({

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "watch": "rollup -w -c",
+    "prepare": "npm run build",
     "build-docs": "cross-env NODE_ENV=production webpack --config docs/webpack.config.js --mode production --progress --hide-modules",
     "dev": "cross-env webpack-dev-server --config docs/webpack.config.js --mode development --open --hot"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -410,9 +410,14 @@ export default class FeatureService {
         this._maxExtent = [extent.xmin, extent.ymin, extent.xmax, extent.ymax]
         this._clearAndRefreshTiles()
       })
-      .catch(() => {
-        this._esriServiceOptions.projectionEndpoint = this._fallbackProjectionEndpoint
-        this._projectBounds()
+      .catch((error) => {
+        // if projection endpoint has already been set to fallback, do not re-request project bounds
+        if (this._projectionEndpointIsFallback()) {
+          throw error
+        } else {
+          this._esriServiceOptions.projectionEndpoint = this._fallbackProjectionEndpoint
+          this._projectBounds()
+        }
       })
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ import tilebelt from '@mapbox/tilebelt'
 import tileDecode from 'arcgis-pbf-parser'
 
 export default class FeatureService {
-
   constructor (sourceId, map, arcgisOptions, geojsonSourceOptions) {
     if (!sourceId || !map || !arcgisOptions) throw new Error('Source id, map and arcgisOptions must be supplied as the first three arguments.')
     if (!arcgisOptions.url) throw new Error('A url must be supplied as part of the esriServiceOptions object.')
@@ -27,7 +26,8 @@ export default class FeatureService {
       setAttributionFromService: true,
       f: 'pbf',
       useSeviceBounds: true,
-      projectionEndpoint: `${arcgisOptions.url.split('rest/services')[0]}rest/services/Geometry/GeometryServer/project`
+      projectionEndpoint: `${arcgisOptions.url.split('rest/services')[0]}rest/services/Geometry/GeometryServer/project`,
+      token: null
     }, arcgisOptions)
 
     this._fallbackProjectionEndpoint = 'https://tasks.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project'
@@ -125,6 +125,11 @@ export default class FeatureService {
   setDate (to, from) {
     this._esriServiceOptions.to = to
     this._esriServiceOptions.from = from
+    this._clearAndRefreshTiles()
+  }
+
+  setToken(token) {
+    this._esriServiceOptions.token = token
     this._clearAndRefreshTiles()
   }
 
@@ -280,6 +285,8 @@ export default class FeatureService {
 
     if (this._time) params.append('time', this._time)
 
+    this._appendTokenIfExists(params);
+
     return new Promise((resolve) => {
       fetch(`${`${this._esriServiceOptions.url}/query?${params.toString()}`}`)
         .then((response) => { //eslint-disable-line
@@ -312,10 +319,19 @@ export default class FeatureService {
 
   _getServiceMetadata () {
     if (this.serviceMetadata !== null) return Promise.resolve(this.serviceMetadata)
+
+    const params = new URLSearchParams({f: 'json'});
+
+    this._appendTokenIfExists(params);
+
     return new Promise((resolve, reject) => {
-      fetch(`${this._esriServiceOptions.url}?f=json`)
+      fetch(`${this._esriServiceOptions.url}?${params.toString()}`)
         .then(response => response.json())
         .then((data) => {
+          // Esri sends error responses with a 200 status code, so handle them in `.then`
+          if (data.error) {
+            throw new Error(JSON.stringify(data.error));
+          }
           this.serviceMetadata = data
           resolve(this.serviceMetadata)
         })
@@ -346,6 +362,8 @@ export default class FeatureService {
       f: 'geojson'
     })
 
+    this._appendTokenIfExists(params);
+
     return new Promise((resolve) => {
       this._requestJson(`${this._esriServiceOptions.url}/query?${params.toString()}`)
         .then(data => resolve(data))
@@ -363,6 +381,8 @@ export default class FeatureService {
       f: 'geojson'
     })
 
+    this._appendTokenIfExists(params);
+
     return new Promise((resolve) => {
       this._requestJson(`${this._esriServiceOptions.url}/query?${params.toString()}`)
         .then(data => resolve(data))
@@ -379,6 +399,10 @@ export default class FeatureService {
       outSR: 4326,
       f: 'json'
     })
+
+    if (!this._projectionEndpointIsFallback()) {
+      this._appendTokenIfExists(params);
+    }
 
     this._requestJson(`${this._esriServiceOptions.projectionEndpoint}?${params.toString()}`)
       .then((data) => {
@@ -404,6 +428,10 @@ export default class FeatureService {
     })
   }
 
+  _projectionEndpointIsFallback() {
+    return this._esriServiceOptions.projectionEndpoint === this._fallbackProjectionEndpoint
+  }
+
   _setAttribution () {
     const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>'
 
@@ -427,6 +455,12 @@ export default class FeatureService {
     attributionController._updateAttributions()
   }
 
+  _appendTokenIfExists(params) {
+    const token = this._esriServiceOptions.token;
+    if (token !== null) {
+      params.append('token', token)
+    }
+  }
 }
 
 


### PR DESCRIPTION
Adds `token` option and `setToken` method, allowing for authenticated requests to esri.

Also added (& happy to take any of this out)
- `watch` and `prepare` script.
  - `prepare` script  sets up dist directory when using a forked version of this repository
- throwing an error in metadata fetch if esri service returns a response with a non-falsy `error` key (e.g., `{ error: { code: 499, message: "Token required", details: [] } }`)
- not calling `this._projectBounds()` in `_projectBounds()` catch statement if already using the fallback projection endpoint. When I was (mistakenly) appending a token to the fallback projection request, it resulted in endless failed requests to that endpoint

I also want to add:

a) In my private fork of this repo, I have added babel in order to be able to use private classes (e.g., `#map`). The `_map` namespace somehow gets polluted, with very strange results. Changing it to `#map` solves this issue. Generally it looks something like
```js
export default class FeatureService {
  static #fallbackProjectionEndpoint = 'https://tasks.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer/project';

  #map;
  #maxExtent = [-Infinity, Infinity, -Infinity, Infinity];
  #esriServiceOptions;
  #tileIndices = new Map();
  #featureIndices = new Map();
  #featureCollections = new Map();
  #boundEvent = null;
  #layerId = null;

  serviceMetadata = null;
  ....
```
Adding babel seemed like a pretty major change, and it also seems to require updating the eslint-config from mourner (I at least couldn't get it to work using `babel-eslint` as the parser option.)

Anyhow, if you'd like, I can make a different PR that implements those changes. I've also updated the fork to have the option to disable requests by default, as well as some minor tweaks like checking if requests are enabled in `_clearAndRefreshTiles` before initiating a tile request from there.

b) Thank you again (so much) for this project!!! I had been looking for a solution to this for a while, and when this somehow magically appeared 3 months ago I almost couldn't believe it :)