### PR TITLE
Fix: Swap around when to add fetchOptions to `_projectBounds`

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -388,9 +388,9 @@ export default class FeatureService {
       outSR: 4326,
       f: 'json'
     })
-    let fetchOptions = this._esriServiceOptions.fetchOptions
+    let fetchOptions = {}
     if (!this._projectionEndpointIsFallback()) {
-      fetchOptions = {}
+      fetchOptions = this._esriServiceOptions.fetchOptions
       this._appendTokenIfExists(params)
     }
 


### PR DESCRIPTION
Accidentally missed the `!` in the conditional. We only want to add the `fetchOptions` when we're calling the endpoint we specify, but in the case when it's a fallback, we want to omit the `fetchOptions`