### PR TITLE
fix: error if source is undefined

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -302,7 +302,13 @@ export default class FeatureService {
   }
 
   _updateFcOnMap(fc) {
-    this._map.getSource(this.sourceId).setData(fc)
+    const source = this._map.getSource(this.sourceId);
+    if(source){
+      source.setData(fc)
+    }
+    else{
+      console.warn(`Cannot find source with id: ${this.sourceId}`)
+    }
   }
 
   _doesTileOverlapBbox(tile, bbox) {


### PR DESCRIPTION
In `updateFcOnMap` method, an `cannot read 'setData' of undefined`  error will be if the original source no longer exists.
This could happen when the request has been sent but before response arriving, the feature layer is removed (e.g. user quickly turn on/off a feature layer switch in the UI).