### PR TITLE
fix duplicated attribution as well as disabled setAttributionFromService

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -437,11 +437,11 @@ export default class FeatureService {
 
     const attributionController = this._map._controls.find(c => '_attribHTML' in c)
 
-    if (!attributionController) return
+    if (!attributionController || !this._esriServiceOptions.setAttributionFromService) return
 
     const customAttribution = attributionController.options.customAttribution
-
-    if (typeof customAttribution === 'string') {
+    
+    if (typeof customAttribution === 'string' && !customAttribution.includes(POWERED_BY_ESRI_ATTRIBUTION_STRING)) {
       attributionController.options.customAttribution = `${customAttribution} | ${POWERED_BY_ESRI_ATTRIBUTION_STRING}`
     } else if (customAttribution === undefined) {
       attributionController.options.customAttribution = POWERED_BY_ESRI_ATTRIBUTION_STRING


### PR DESCRIPTION
Hi there, thanks for making this library available!

I noticed a bug- when switching layers, the `powered by Esri` attribution gets duplicated 


<img width="1496" alt="Screenshot 2025-05-12 at 10 50 07 AM" src="https://github.com/user-attachments/assets/a648a9d1-e202-4d37-b5d9-b9ea56dae358" />


Additionally, if I set the setAttributionFromService: false, I see that the attribution gets updated either way.

